### PR TITLE
fix(harness): 하네스 세팅 견고화 — 인코딩·훅·구조 개선

### DIFF
--- a/.claude/commands/harness.md
+++ b/.claude/commands/harness.md
@@ -73,11 +73,15 @@
 
 상태 전이와 자동 기록 필드:
 
-| 전이 | 기록되는 필드 | 기록 주체 |
-|------|-------------|----------|
-| → `completed` | `completed_at`, `summary` | Claude 세션 (summary), execute.py (timestamp) |
-| → `error` | `failed_at`, `error_message` | Claude 세션 (message), execute.py (timestamp) |
-| → `blocked` | `blocked_at`, `blocked_reason` | Claude 세션 (reason), execute.py (timestamp) |
+step을 실행하는 Claude 세션은 **index.json을 직접 수정하지 않는다**. 대신 결과를
+`phases/{task-name}/step{N}.result.json`에 쓰고, execute.py가 그것을 읽어 index.json에
+머지하면서 타임스탬프를 기록한다 (index.json은 execute.py 단독 소유).
+
+| 전이 | result.json에 담는 필드 | execute.py가 머지하며 추가하는 필드 |
+|------|------------------------|--------------------------------|
+| → `completed` | `status`, `summary` | `completed_at` |
+| → `error` | `status`, `error_message` | `failed_at` |
+| → `blocked` | `status`, `blocked_reason` | `blocked_at` |
 
 `summary`는 step 완료 시 산출물을 한 줄로 요약한 것으로, execute.py가 다음 step 프롬프트에 컨텍스트로 누적 전달한다. 따라서 다음 step에 유용한 정보(생성된 파일, 핵심 결정 등)를 담아야 한다.
 
@@ -107,6 +111,9 @@
 ## Acceptance Criteria
 
 ```bash
+# 프로젝트 스택에 맞는 실제 검증 커맨드로 교체하라.
+# 예 (Node): npm run build && npm test
+# 예 (Python): python -m pytest -q
 npm run build   # 컴파일 에러 없음
 npm test        # 테스트 통과
 ```
@@ -118,10 +125,12 @@ npm test        # 테스트 통과
    - ARCHITECTURE.md 디렉토리 구조를 따르는가?
    - ADR 기술 스택을 벗어나지 않았는가?
    - CLAUDE.md CRITICAL 규칙을 위반하지 않았는가?
-3. 결과에 따라 `phases/{task-name}/index.json`의 해당 step을 업데이트한다:
-   - 성공 → `"status": "completed"`, `"summary": "산출물 한 줄 요약"`
-   - 수정 3회 시도 후에도 실패 → `"status": "error"`, `"error_message": "구체적 에러 내용"`
-   - 사용자 개입 필요 (API 키, 외부 인증, 수동 설정 등) → `"status": "blocked"`, `"blocked_reason": "구체적 사유"` 후 즉시 중단
+3. 결과를 `phases/{task-name}/step{N}.result.json` 파일에 기록한다.
+   **index.json은 직접 수정하지 않는다** — 하네스(execute.py)가 단독 관리하며,
+   이 result 파일을 읽어 index.json에 머지한다.
+   - 성공 → `{ "status": "completed", "summary": "산출물 한 줄 요약" }`
+   - 수정 3회 시도 후에도 실패 → `{ "status": "error", "error_message": "구체적 에러 내용" }`
+   - 사용자 개입 필요 (API 키, 외부 인증, 수동 설정 등) → `{ "status": "blocked", "blocked_reason": "구체적 사유" }` 후 즉시 중단
 
 ## 금지사항
 
@@ -132,8 +141,9 @@ npm test        # 테스트 통과
 ### E. 실행
 
 ```bash
-python3 scripts/execute.py {task-name}        # 순차 실행
-python3 scripts/execute.py {task-name} --push  # 실행 후 push
+python scripts/execute.py {task-name}          # 순차 실행 (Windows: python, Unix: python3)
+python scripts/execute.py {task-name} --push    # 실행 후 push
+python scripts/execute.py {task-name} --strict  # docs에 {placeholder} 남아있으면 중단
 ```
 
 execute.py가 자동으로 처리하는 것:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,18 +6,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run lint 2>&1 && npm run build 2>&1 && npm run test 2>&1"
+            "command": "python scripts/verify.py"
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|PowerShell",
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm\\s+-rf|git\\s+push\\s+--force|git\\s+reset\\s+--hard|DROP\\s+TABLE'; then echo 'BLOCKED: 위험한 명령어가 감지되었습니다.' >&2; exit 1; fi"
+            "command": "python scripts/guard.py"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,15 @@ out/
 next-env.d.ts
 tsconfig.tsbuildinfo
 
-# phase execution outputs
+# python
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# phase execution outputs (ephemeral — produced by execute.py / child sessions)
 phases/**/phase*-output.json
 phases/**/step*-output.json
+phases/**/step*.result.json
+
+# example smoke-test artifact
+phases/example/HELLO.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Harness Framework
+
+새 프로젝트를 시작할 때마다 복사해 쓰는 **재사용 개발 하네스**다.
+프로젝트의 기획·아키텍처 문서를 가드레일로 삼아, 구현 작업을 여러 *step*으로 쪼갠 뒤
+`scripts/execute.py`가 각 step을 독립된 Claude Code 세션으로 순차 실행한다.
+
+각 세션은 빈 맥락에서 시작하지만, 하네스가 매 step마다 다음을 자동 주입한다:
+- **가드레일** — `CLAUDE.md` + `docs/*.md` 전체
+- **누적 컨텍스트** — 앞서 완료된 step들의 한 줄 요약(summary)
+- **자가 교정** — 실패 시 직전 에러를 피드백하며 최대 3회 재시도
+
+## 요구사항
+
+- Python 3.9+ (`python`이 PATH에 있어야 함 — Windows는 `python`, Unix는 보통 `python3`)
+- [Claude Code CLI](https://claude.com/claude-code) (`claude`가 PATH에 있어야 함)
+- (도구 개발/테스트용) `pip install -r requirements-dev.txt`
+
+## 새 프로젝트 시작 절차
+
+1. **이 레포를 복사**해 새 프로젝트의 출발점으로 삼는다.
+2. **가드레일 문서를 채운다** — `CLAUDE.md`, `docs/PRD.md`, `docs/ARCHITECTURE.md`,
+   `docs/ADR.md`, `docs/UI_GUIDE.md`의 `{placeholder}`를 실제 내용으로 교체한다.
+   (안 채우면 execute.py가 실행 시 경고한다. `--strict`면 중단.)
+3. **step을 설계한다** — Claude Code에서 `/harness` 커맨드를 실행하면 워크플로우에 따라
+   `phases/{task}/index.json`과 `step{N}.md`들을 만들어 준다.
+4. **실행한다**:
+
+   ```bash
+   python scripts/execute.py {task}            # 순차 실행
+   python scripts/execute.py {task} --push      # 완료 후 origin push
+   python scripts/execute.py {task} --strict    # placeholder 남아있으면 중단
+   ```
+
+   > `feat-{task}` 브랜치에서 실행된다. **main(또는 깨끗한 기준 브랜치)에서 시작**하길 권장한다.
+
+## 동작 한눈에 보기
+
+```
+phases/
+├── index.json              # 전체 task 현황 (execute.py가 status 갱신)
+└── {task}/
+    ├── index.json          # 이 task의 step 목록 + 상태 (execute.py 단독 소유)
+    ├── step0.md            # 각 step의 지시서 (사람이/​/harness가 작성)
+    ├── step1.md
+    ├── step{N}.result.json # 자식 세션이 결과를 보고하는 파일 (gitignore, 임시)
+    └── step{N}-output.json # Claude 원시 출력 로그 (gitignore, 디버그용)
+```
+
+- **index.json은 execute.py가 단독으로 쓴다.** step 세션은 절대 수정하지 않고,
+  결과를 `step{N}.result.json`에 적는다 → execute.py가 읽어 index.json에 머지한다.
+  (두 주체가 같은 파일을 쓰다 summary/timestamp가 유실되는 것을 막기 위함)
+- 상태: `pending` → `completed` | `error` | `blocked`. 타임스탬프는 execute.py가 기록.
+
+### 에러 복구
+
+- **error**: 해당 step의 `status`를 `pending`으로 되돌리고 `error_message`를 지운 뒤 재실행.
+- **blocked**: `blocked_reason`의 사유(API 키 등)를 해결하고 같은 방식으로 재실행.
+
+> 재시도 시, 직전 시도가 만든 *커밋되지 않은* 변경은 작업 트리에 남아 다음 시도에 누적될 수
+> 있다. 깨끗한 재시도가 필요하면 수동으로 `git stash`/정리 후 실행하라.
+
+## 자동화 훅 (`.claude/settings.json`)
+
+- **PreToolUse** (`scripts/guard.py`) — Bash/PowerShell의 위험 명령(`rm -rf`,
+  `git push --force`, `DROP TABLE`, `Remove-Item -Recurse -Force` 등)을 차단한다.
+  자식 세션은 `--dangerously-skip-permissions`로 돌기 때문에 이 훅이 사실상 유일한 안전망이다.
+- **Stop** (`scripts/verify.py`) — 프로젝트 종류를 자동 감지해 검증한다
+  (`package.json`→npm 스크립트, `pyproject.toml`/`pytest.ini` 등→pytest, 없으면 통과).
+  `HARNESS_NO_VERIFY=1`로 끌 수 있고, 하네스 자식 세션(`HARNESS_CHILD`)에서는 자동 스킵된다.
+
+## 하네스 도구 개발
+
+```bash
+pip install -r requirements-dev.txt
+python -m pytest scripts/ -q
+```
+
+## 빠른 체험
+
+```bash
+python scripts/execute.py example
+```
+
+`phases/example/`의 무해한 스모크 테스트 step이 실행되며 전체 흐름을 한 바퀴 돌려볼 수 있다.

--- a/phases/example/index.json
+++ b/phases/example/index.json
@@ -1,0 +1,7 @@
+{
+  "project": "Harness Example",
+  "phase": "example",
+  "steps": [
+    { "step": 0, "name": "smoke-test", "status": "pending" }
+  ]
+}

--- a/phases/example/step0.md
+++ b/phases/example/step0.md
@@ -1,0 +1,37 @@
+# Step 0: smoke-test
+
+이 step은 하네스 실행 흐름을 처음 체험해보기 위한 **무해한 예제**다.
+실제 빌드나 외부 의존성 없이, 파일 하나를 만들고 결과를 보고하는 것까지만 한다.
+
+## 읽어야 할 파일
+
+- `README.md` — 하네스가 어떻게 동작하는지
+- `.claude/commands/harness.md` — step/result 규약
+
+## 작업
+
+1. 레포 루트에 `phases/example/HELLO.md` 파일을 만들고, 다음 한 줄을 적어라:
+
+   ```
+   하네스 스모크 테스트 성공 — <현재 시각>
+   ```
+
+2. 이 파일 외에 다른 파일은 만들거나 수정하지 마라.
+
+## Acceptance Criteria
+
+```bash
+# 파일이 생성되었는지 확인
+test -f phases/example/HELLO.md
+```
+
+## 검증 절차
+
+1. 위 파일이 존재하는지 확인한다.
+2. 결과를 `phases/example/step0.result.json`에 기록한다 (index.json은 수정하지 마라):
+   - 성공 → `{ "status": "completed", "summary": "HELLO.md 생성, 스모크 테스트 통과" }`
+
+## 금지사항
+
+- 레포의 다른 파일을 건드리지 마라. 이유: 이 step은 흐름 확인용 스모크 테스트일 뿐이다.
+- `index.json`을 직접 수정하지 마라. 이유: 하네스(execute.py)가 단독 관리한다.

--- a/phases/index.json
+++ b/phases/index.json
@@ -1,0 +1,8 @@
+{
+  "phases": [
+    {
+      "dir": "example",
+      "status": "pending"
+    }
+  ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# 하네스 도구 자체를 개발/테스트하기 위한 의존성
+# 설치: pip install -r requirements-dev.txt
+pytest>=7.0

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -10,6 +10,8 @@ import argparse
 import contextlib
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -58,13 +60,14 @@ class StepExecutor:
     CHORE_MSG = "chore({phase}): step {num} output"
     TZ = timezone(timedelta(hours=9))
 
-    def __init__(self, phase_dir_name: str, *, auto_push: bool = False):
+    def __init__(self, phase_dir_name: str, *, auto_push: bool = False, strict: bool = False):
         self._root = str(ROOT)
         self._phases_dir = ROOT / "phases"
         self._phase_dir = self._phases_dir / phase_dir_name
         self._phase_dir_name = phase_dir_name
         self._top_index_file = self._phases_dir / "index.json"
         self._auto_push = auto_push
+        self._strict = strict
 
         if not self._phase_dir.is_dir():
             print(f"ERROR: {self._phase_dir} not found")
@@ -82,9 +85,11 @@ class StepExecutor:
 
     def run(self):
         self._print_header()
+        self._validate_plan()
         self._check_blockers()
         self._checkout_branch()
         guardrails = self._load_guardrails()
+        self._warn_placeholders(guardrails)
         self._ensure_created_at()
         self._execute_all_steps(guardrails)
         self._finalize()
@@ -102,7 +107,15 @@ class StepExecutor:
 
     @staticmethod
     def _write_json(p: Path, data: dict):
-        p.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        """index.json 등 진실원본을 원자적으로 교체한다.
+
+        temp 파일에 먼저 쓰고 os.replace로 교체하므로, 쓰기 도중 중단돼도
+        기존 파일이 깨진 JSON으로 남지 않는다.
+        """
+        text = json.dumps(data, indent=2, ensure_ascii=False)
+        tmp = p.with_name(p.name + ".tmp")
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, p)
 
     # --- git ---
 
@@ -178,12 +191,28 @@ class StepExecutor:
         sections = []
         claude_md = ROOT / "CLAUDE.md"
         if claude_md.exists():
-            sections.append(f"## 프로젝트 규칙 (CLAUDE.md)\n\n{claude_md.read_text()}")
+            sections.append(f"## 프로젝트 규칙 (CLAUDE.md)\n\n{claude_md.read_text(encoding='utf-8')}")
         docs_dir = ROOT / "docs"
         if docs_dir.is_dir():
             for doc in sorted(docs_dir.glob("*.md")):
-                sections.append(f"## {doc.stem}\n\n{doc.read_text()}")
+                sections.append(f"## {doc.stem}\n\n{doc.read_text(encoding='utf-8')}")
         return "\n\n---\n\n".join(sections) if sections else ""
+
+    def _warn_placeholders(self, guardrails: str):
+        """가드레일에 아직 채우지 않은 {...} 템플릿 placeholder가 남아있으면 경고한다.
+
+        이 레포는 재사용 하네스라 docs는 새 프로젝트에서 채워진다. 안 채운 채
+        실행하면 빈 껍데기가 매 step 프롬프트에 주입되므로 사용자에게 알린다.
+        """
+        placeholders = re.findall(r"\{[^{}\n]{1,60}\}", guardrails)
+        if not placeholders:
+            return
+        sample = ", ".join(sorted(set(placeholders))[:5])
+        print(f"  ⚠ 가드레일에 미완성 템플릿 placeholder {len(placeholders)}개 발견: {sample} ...")
+        print(f"    CLAUDE.md / docs/*.md 를 프로젝트 내용으로 채우는 것을 권장합니다.")
+        if self._strict:
+            print(f"  ERROR: --strict 모드이므로 중단합니다.")
+            sys.exit(1)
 
     @staticmethod
     def _build_step_context(index: dict) -> str:
@@ -196,11 +225,15 @@ class StepExecutor:
             return ""
         return "## 이전 Step 산출물\n\n" + "\n".join(lines) + "\n\n"
 
-    def _build_preamble(self, guardrails: str, step_context: str,
+    def _result_file(self, step_num: int) -> Path:
+        return self._phase_dir / f"step{step_num}.result.json"
+
+    def _build_preamble(self, guardrails: str, step_context: str, step_num: int,
                         prev_error: Optional[str] = None) -> str:
         commit_example = self.FEAT_MSG.format(
             phase=self._phase_name, num="N", name="<step-name>"
         )
+        result_rel = f"phases/{self._phase_dir_name}/step{step_num}.result.json"
         retry_section = ""
         if prev_error:
             retry_section = (
@@ -216,15 +249,26 @@ class StepExecutor:
             f"2. 이 step에 명시된 작업만 수행하라. 추가 기능이나 파일을 만들지 마라.\n"
             f"3. 기존 테스트를 깨뜨리지 마라.\n"
             f"4. AC(Acceptance Criteria) 검증을 직접 실행하라.\n"
-            f"5. /phases/{self._phase_dir_name}/index.json의 해당 step status를 업데이트하라:\n"
-            f"   - AC 통과 → \"completed\" + \"summary\" 필드에 이 step의 산출물을 한 줄로 요약\n"
-            f"   - {self.MAX_RETRIES}회 수정 시도 후에도 실패 → \"error\" + \"error_message\" 기록\n"
-            f"   - 사용자 개입이 필요한 경우 (API 키, 인증, 수동 설정 등) → \"blocked\" + \"blocked_reason\" 기록 후 즉시 중단\n"
-            f"6. 모든 변경사항을 커밋하라:\n"
+            f"5. index.json은 절대 수정하지 마라 (하네스가 단독 관리한다). "
+            f"대신 작업 결과를 `{result_rel}` 파일에 JSON으로 기록하라:\n"
+            f"   - AC 통과 → {{\"status\": \"completed\", \"summary\": \"이 step의 산출물 한 줄 요약\"}}\n"
+            f"   - {self.MAX_RETRIES}회 수정 시도 후에도 실패 → {{\"status\": \"error\", \"error_message\": \"구체적 에러\"}}\n"
+            f"   - 사용자 개입 필요 (API 키, 인증, 수동 설정 등) → {{\"status\": \"blocked\", \"blocked_reason\": \"사유\"}} 후 즉시 중단\n"
+            f"6. 코드 변경사항만 커밋하라 (result.json은 커밋하지 마라):\n"
             f"   {commit_example}\n\n---\n\n"
         )
 
     # --- Claude 호출 ---
+
+    @staticmethod
+    def _resolve_claude() -> str:
+        """claude 실행 파일 경로를 해석한다 (Windows의 .cmd 래퍼 포함)."""
+        exe = shutil.which("claude")
+        if exe is None:
+            print(f"  ERROR: 'claude' CLI를 PATH에서 찾을 수 없습니다.")
+            print(f"  Hint: Claude Code CLI를 설치하고 PATH에 등록하세요.")
+            sys.exit(1)
+        return exe
 
     def _invoke_claude(self, step: dict, preamble: str) -> dict:
         step_num, step_name = step["step"], step["name"]
@@ -234,27 +278,51 @@ class StepExecutor:
             print(f"  ERROR: {step_file} not found")
             sys.exit(1)
 
-        prompt = preamble + step_file.read_text()
-        result = subprocess.run(
-            ["claude", "-p", "--dangerously-skip-permissions", "--output-format", "json", prompt],
-            cwd=self._root, capture_output=True, text=True, timeout=1800,
-        )
+        # 프롬프트는 stdin으로 전달한다. argv로 넘기면 Windows의 명령줄 길이
+        # 한계(32767자)를 가드레일+docs가 초과해 실행이 실패할 수 있다.
+        prompt = preamble + step_file.read_text(encoding="utf-8")
+        # 자식 세션이 Stop 훅에서 verify를 재귀 실행하지 않도록 표시한다.
+        child_env = {**os.environ, "HARNESS_CHILD": "1"}
 
-        if result.returncode != 0:
-            print(f"\n  WARN: Claude가 비정상 종료됨 (code {result.returncode})")
-            if result.stderr:
-                print(f"  stderr: {result.stderr[:500]}")
+        try:
+            result = subprocess.run(
+                [self._resolve_claude(), "-p", "--dangerously-skip-permissions",
+                 "--output-format", "json"],
+                cwd=self._root, capture_output=True, text=True, encoding="utf-8",
+                input=prompt, env=child_env, timeout=1800,
+            )
+            exit_code, stdout, stderr = result.returncode, result.stdout, result.stderr
+        except subprocess.TimeoutExpired as e:
+            print(f"\n  WARN: Claude가 1800초 내에 끝나지 않아 타임아웃되었습니다.")
+            exit_code, stdout, stderr = -1, (e.stdout or ""), "TimeoutExpired (1800s)"
+
+        if exit_code != 0:
+            print(f"\n  WARN: Claude가 비정상 종료됨 (code {exit_code})")
+            if stderr:
+                print(f"  stderr: {stderr[:500]}")
 
         output = {
             "step": step_num, "name": step_name,
-            "exitCode": result.returncode,
-            "stdout": result.stdout, "stderr": result.stderr,
+            "exitCode": exit_code,
+            "stdout": stdout, "stderr": stderr,
         }
         out_path = self._phase_dir / f"step{step_num}-output.json"
-        with open(out_path, "w") as f:
-            json.dump(output, f, indent=2, ensure_ascii=False)
+        out_path.write_text(
+            json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
 
         return output
+
+    def _read_step_result(self, step_num: int) -> Optional[dict]:
+        """자식이 남긴 step{N}.result.json을 읽는다. 없거나 깨졌으면 None."""
+        rf = self._result_file(step_num)
+        if not rf.exists():
+            return None
+        try:
+            data = self._read_json(rf)
+        except (json.JSONDecodeError, OSError):
+            return None
+        return data if isinstance(data, dict) else None
 
     # --- 헤더 & 검증 ---
 
@@ -265,6 +333,41 @@ class StepExecutor:
         if self._auto_push:
             print(f"  Auto-push: enabled")
         print(f"{'='*60}")
+
+    def _validate_plan(self):
+        """실행 전에 plan(index.json + step 파일)의 정합성을 선검증한다.
+
+        중반에 터지지 않도록, 누락/비순차/필수필드 없음 등을 미리 잡는다.
+        """
+        index = self._read_json(self._index_file)
+        steps = index.get("steps")
+        if not isinstance(steps, list) or not steps:
+            print(f"  ERROR: index.json에 steps 배열이 없거나 비어있습니다.")
+            sys.exit(1)
+
+        valid_status = {"pending", "completed", "error", "blocked"}
+        seen_pending = False
+        for i, s in enumerate(steps):
+            for field in ("step", "name", "status"):
+                if field not in s:
+                    print(f"  ERROR: steps[{i}]에 '{field}' 필드가 없습니다.")
+                    sys.exit(1)
+            if s["step"] != i:
+                print(f"  ERROR: step 번호가 0부터 순차가 아닙니다 (steps[{i}].step={s['step']}).")
+                sys.exit(1)
+            if s["status"] not in valid_status:
+                print(f"  ERROR: steps[{i}].status='{s['status']}'는 허용되지 않습니다 {valid_status}.")
+                sys.exit(1)
+            # 완료 뒤에 미완료가 다시 오면 안 됨 (_check_blockers 역방향 스캔 엣지케이스 방지)
+            if s["status"] == "pending":
+                seen_pending = True
+            elif s["status"] == "completed" and seen_pending:
+                print(f"  ERROR: 완료된 step{s['step']}이 미완료 step 뒤에 있습니다. 순서가 깨졌습니다.")
+                sys.exit(1)
+            step_file = self._phase_dir / f"step{s['step']}.md"
+            if s["status"] == "pending" and not step_file.exists():
+                print(f"  ERROR: {step_file} 가 없습니다. step 파일을 먼저 작성하세요.")
+                sys.exit(1)
 
     def _check_blockers(self):
         index = self._read_json(self._index_file)
@@ -290,6 +393,18 @@ class StepExecutor:
 
     # --- 실행 루프 ---
 
+    def _set_step_fields(self, step_num: int, **fields):
+        """index.json의 특정 step에 필드를 머지한다 (index.json은 부모 단독 소유)."""
+        index = self._read_json(self._index_file)
+        for s in index["steps"]:
+            if s["step"] == step_num:
+                for k, v in fields.items():
+                    if v is None:
+                        s.pop(k, None)
+                    else:
+                        s[k] = v
+        self._write_json(self._index_file, index)
+
     def _execute_single_step(self, step: dict, guardrails: str) -> bool:
         """단일 step 실행 (재시도 포함). 완료되면 True, 실패/차단이면 False."""
         step_num, step_name = step["step"], step["name"]
@@ -299,60 +414,58 @@ class StepExecutor:
         for attempt in range(1, self.MAX_RETRIES + 1):
             index = self._read_json(self._index_file)
             step_context = self._build_step_context(index)
-            preamble = self._build_preamble(guardrails, step_context, prev_error)
+            preamble = self._build_preamble(guardrails, step_context, step_num, prev_error)
 
             tag = f"Step {step_num}/{self._total - 1} ({done} done): {step_name}"
             if attempt > 1:
                 tag += f" [retry {attempt}/{self.MAX_RETRIES}]"
 
+            # 이전 시도의 결과 파일이 남아 오판하지 않도록 먼저 제거한다.
+            self._result_file(step_num).unlink(missing_ok=True)
+
             with progress_indicator(tag) as pi:
                 self._invoke_claude(step, preamble)
                 elapsed = int(pi.elapsed)
 
-            index = self._read_json(self._index_file)
-            status = next((s.get("status", "pending") for s in index["steps"] if s["step"] == step_num), "pending")
+            result = self._read_step_result(step_num)
+            status = result.get("status") if result else None
             ts = self._stamp()
 
             if status == "completed":
-                for s in index["steps"]:
-                    if s["step"] == step_num:
-                        s["completed_at"] = ts
-                self._write_json(self._index_file, index)
+                self._set_step_fields(
+                    step_num, status="completed",
+                    summary=result.get("summary", ""), completed_at=ts,
+                    error_message=None, blocked_reason=None,
+                )
+                self._result_file(step_num).unlink(missing_ok=True)
                 self._commit_step(step_num, step_name)
                 print(f"  ✓ Step {step_num}: {step_name} [{elapsed}s]")
                 return True
 
             if status == "blocked":
-                for s in index["steps"]:
-                    if s["step"] == step_num:
-                        s["blocked_at"] = ts
-                self._write_json(self._index_file, index)
-                reason = next((s.get("blocked_reason", "") for s in index["steps"] if s["step"] == step_num), "")
+                reason = result.get("blocked_reason", "") if result else ""
+                self._set_step_fields(step_num, status="blocked",
+                                      blocked_reason=reason, blocked_at=ts)
                 print(f"  ⏸ Step {step_num}: {step_name} blocked [{elapsed}s]")
                 print(f"    Reason: {reason}")
                 self._update_top_index("blocked")
                 sys.exit(2)
 
-            err_msg = next(
-                (s.get("error_message", "Step did not update status") for s in index["steps"] if s["step"] == step_num),
-                "Step did not update status",
-            )
+            # status == "error" 이거나, 결과 파일이 없음(미보고)
+            if result and result.get("error_message"):
+                err_msg = result["error_message"]
+            else:
+                err_msg = "Step이 결과(step{N}.result.json)를 보고하지 않았습니다."
 
             if attempt < self.MAX_RETRIES:
-                for s in index["steps"]:
-                    if s["step"] == step_num:
-                        s["status"] = "pending"
-                        s.pop("error_message", None)
-                self._write_json(self._index_file, index)
                 prev_error = err_msg
                 print(f"  ↻ Step {step_num}: retry {attempt}/{self.MAX_RETRIES} — {err_msg}")
             else:
-                for s in index["steps"]:
-                    if s["step"] == step_num:
-                        s["status"] = "error"
-                        s["error_message"] = f"[{self.MAX_RETRIES}회 시도 후 실패] {err_msg}"
-                        s["failed_at"] = ts
-                self._write_json(self._index_file, index)
+                self._set_step_fields(
+                    step_num, status="error",
+                    error_message=f"[{self.MAX_RETRIES}회 시도 후 실패] {err_msg}",
+                    failed_at=ts,
+                )
                 self._commit_step(step_num, step_name)
                 print(f"  ✗ Step {step_num}: {step_name} failed after {self.MAX_RETRIES} attempts [{elapsed}s]")
                 print(f"    Error: {err_msg}")
@@ -408,9 +521,11 @@ def main():
     parser = argparse.ArgumentParser(description="Harness Step Executor")
     parser.add_argument("phase_dir", help="Phase directory name (e.g. 0-mvp)")
     parser.add_argument("--push", action="store_true", help="Push branch after completion")
+    parser.add_argument("--strict", action="store_true",
+                        help="Abort if guardrail docs still contain {placeholder} templates")
     args = parser.parse_args()
 
-    StepExecutor(args.phase_dir, auto_push=args.push).run()
+    StepExecutor(args.phase_dir, auto_push=args.push, strict=args.strict).run()
 
 
 if __name__ == "__main__":

--- a/scripts/guard.py
+++ b/scripts/guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+PreToolUse 훅용 위험명령 차단기 — stdin으로 들어온 훅 JSON을 파싱해
+Bash / PowerShell 명령에 위험 패턴이 있으면 차단한다.
+
+자식 세션은 `--dangerously-skip-permissions`로 돌기 때문에, 이 훅이 사실상
+유일한 안전망이다. 따라서 Bash와 PowerShell 도구를 모두 검사한다.
+
+종료 코드:
+    0 — 허용
+    2 — 차단. Claude Code는 PreToolUse 훅이 2를 반환하면 도구 실행을 막고
+        stderr를 모델에 되먹인다.
+
+훅 입력(JSON, stdin):
+    { "tool_name": "Bash", "tool_input": { "command": "..." }, ... }
+"""
+
+import contextlib
+import json
+import re
+import sys
+
+# Windows 콘솔(cp949)에서도 한글 메시지가 깨지지 않도록 stderr를 utf-8로 맞춘다.
+with contextlib.suppress(Exception):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+# 위험 패턴. 단어경계/플래그를 함께 봐서 커밋 메시지 등의 단순 언급은 오탐하지 않는다.
+DANGEROUS = [
+    (r"\brm\s+-[a-z]*[rf][a-z]*\s", "rm -rf 류 재귀/강제 삭제"),
+    (r"\bgit\s+push\s+.*--force\b", "git push --force"),
+    (r"\bgit\s+push\s+.*-f\b", "git push -f"),
+    (r"\bgit\s+reset\s+--hard\b", "git reset --hard"),
+    (r"\bgit\s+clean\s+-[a-z]*f", "git clean -f"),
+    (r"\bDROP\s+TABLE\b", "DROP TABLE"),
+    (r"\bDROP\s+DATABASE\b", "DROP DATABASE"),
+    (r"\bTRUNCATE\s+TABLE\b", "TRUNCATE TABLE"),
+    (r"\bmkfs\b", "mkfs (파일시스템 포맷)"),
+    (r":\(\)\s*\{\s*:\|:&\s*\};:", "fork bomb"),
+    # PowerShell
+    (r"\bRemove-Item\b.*-Recurse\b.*-Force\b", "Remove-Item -Recurse -Force"),
+    (r"\bRemove-Item\b.*-Force\b.*-Recurse\b", "Remove-Item -Force -Recurse"),
+    (r"\bFormat-Volume\b", "Format-Volume"),
+]
+
+
+def _extract_command(payload: dict) -> str:
+    """Bash / PowerShell 도구 입력에서 실행 문자열을 뽑는다."""
+    ti = payload.get("tool_input") or {}
+    if not isinstance(ti, dict):
+        return ""
+    # Bash, PowerShell 둘 다 'command' 필드를 쓴다.
+    parts = []
+    for key in ("command", "script"):
+        val = ti.get(key)
+        if isinstance(val, str):
+            parts.append(val)
+    return "\n".join(parts)
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        # 입력을 해석 못하면 차단하지 않는다 (가용성 우선).
+        return 0
+
+    command = _extract_command(payload)
+    if not command:
+        return 0
+
+    for pattern, label in DANGEROUS:
+        if re.search(pattern, command, re.IGNORECASE):
+            print(f"BLOCKED: 위험한 명령어가 감지되었습니다 — {label}", file=sys.stderr)
+            print(f"  명령: {command[:200]}", file=sys.stderr)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_execute.py
+++ b/scripts/test_execute.py
@@ -29,12 +29,12 @@ def tmp_project(tmp_path):
     phases_dir.mkdir()
 
     claude_md = tmp_path / "CLAUDE.md"
-    claude_md.write_text("# Rules\n- rule one\n- rule two")
+    claude_md.write_text("# Rules\n- rule one\n- rule two", encoding="utf-8")
 
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
-    (docs_dir / "arch.md").write_text("# Architecture\nSome content")
-    (docs_dir / "guide.md").write_text("# Guide\nAnother doc")
+    (docs_dir / "arch.md").write_text("# Architecture\nSome content", encoding="utf-8")
+    (docs_dir / "guide.md").write_text("# Guide\nAnother doc", encoding="utf-8")
 
     return tmp_path
 
@@ -54,8 +54,8 @@ def phase_dir(tmp_project):
             {"step": 2, "name": "ui", "status": "pending"},
         ],
     }
-    (d / "index.json").write_text(json.dumps(index, indent=2, ensure_ascii=False))
-    (d / "step2.md").write_text("# Step 2: UI\n\nUI를 구현하세요.")
+    (d / "index.json").write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+    (d / "step2.md").write_text("# Step 2: UI\n\nUI를 구현하세요.", encoding="utf-8")
 
     return d
 
@@ -70,7 +70,7 @@ def top_index(tmp_project):
         ]
     }
     p = tmp_project / "phases" / "index.json"
-    p.write_text(json.dumps(top, indent=2))
+    p.write_text(json.dumps(top, indent=2), encoding="utf-8")
     return p
 
 
@@ -126,14 +126,14 @@ class TestJsonHelpers:
     def test_save_ensures_ascii_false(self, tmp_path):
         p = tmp_path / "test.json"
         ex.StepExecutor._write_json(p, {"한글": "테스트"})
-        raw = p.read_text()
+        raw = p.read_text(encoding="utf-8")
         assert "한글" in raw
         assert "\\u" not in raw
 
     def test_save_indented(self, tmp_path):
         p = tmp_path / "test.json"
         ex.StepExecutor._write_json(p, {"a": 1})
-        raw = p.read_text()
+        raw = p.read_text(encoding="utf-8")
         assert "\n" in raw
 
     def test_load_nonexistent_raises(self, tmp_path):
@@ -187,7 +187,7 @@ class TestLoadGuardrails:
             phases_dir = tmp_path / "phases" / "dummy"
             phases_dir.mkdir(parents=True)
             idx = {"project": "T", "phase": "t", "steps": []}
-            (phases_dir / "index.json").write_text(json.dumps(idx))
+            (phases_dir / "index.json").write_text(json.dumps(idx), encoding="utf-8")
             inst = ex.StepExecutor.__new__(ex.StepExecutor)
             result = inst._load_guardrails()
         assert result == ""
@@ -199,18 +199,18 @@ class TestLoadGuardrails:
 
 class TestBuildStepContext:
     def test_includes_completed_with_summary(self, phase_dir):
-        index = json.loads((phase_dir / "index.json").read_text())
+        index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
         result = ex.StepExecutor._build_step_context(index)
         assert "Step 0 (setup): 프로젝트 초기화 완료" in result
         assert "Step 1 (core): 핵심 로직 구현" in result
 
     def test_excludes_pending(self, phase_dir):
-        index = json.loads((phase_dir / "index.json").read_text())
+        index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
         result = ex.StepExecutor._build_step_context(index)
         assert "ui" not in result
 
     def test_excludes_completed_without_summary(self, phase_dir):
-        index = json.loads((phase_dir / "index.json").read_text())
+        index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
         del index["steps"][0]["summary"]
         result = ex.StepExecutor._build_step_context(index)
         assert "setup" not in result
@@ -222,7 +222,7 @@ class TestBuildStepContext:
         assert result == ""
 
     def test_has_header(self, phase_dir):
-        index = json.loads((phase_dir / "index.json").read_text())
+        index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
         result = ex.StepExecutor._build_step_context(index)
         assert result.startswith("## 이전 Step 산출물")
 
@@ -233,43 +233,45 @@ class TestBuildStepContext:
 
 class TestBuildPreamble:
     def test_includes_project_name(self, executor):
-        result = executor._build_preamble("", "")
+        result = executor._build_preamble("", "", 2)
         assert "TestProject" in result
 
     def test_includes_guardrails(self, executor):
-        result = executor._build_preamble("GUARD_CONTENT", "")
+        result = executor._build_preamble("GUARD_CONTENT", "", 2)
         assert "GUARD_CONTENT" in result
 
     def test_includes_step_context(self, executor):
         ctx = "## 이전 Step 산출물\n\n- Step 0: done"
-        result = executor._build_preamble("", ctx)
+        result = executor._build_preamble("", ctx, 2)
         assert "이전 Step 산출물" in result
 
     def test_includes_commit_example(self, executor):
-        result = executor._build_preamble("", "")
+        result = executor._build_preamble("", "", 2)
         assert "feat(mvp):" in result
 
     def test_includes_rules(self, executor):
-        result = executor._build_preamble("", "")
+        result = executor._build_preamble("", "", 2)
         assert "작업 규칙" in result
         assert "AC" in result
 
     def test_no_retry_section_by_default(self, executor):
-        result = executor._build_preamble("", "")
+        result = executor._build_preamble("", "", 2)
         assert "이전 시도 실패" not in result
 
     def test_retry_section_with_prev_error(self, executor):
-        result = executor._build_preamble("", "", prev_error="타입 에러 발생")
+        result = executor._build_preamble("", "", 2, prev_error="타입 에러 발생")
         assert "이전 시도 실패" in result
         assert "타입 에러 발생" in result
 
     def test_includes_max_retries(self, executor):
-        result = executor._build_preamble("", "")
+        result = executor._build_preamble("", "", 2)
         assert str(ex.StepExecutor.MAX_RETRIES) in result
 
-    def test_includes_index_path(self, executor):
-        result = executor._build_preamble("", "")
-        assert "/phases/0-mvp/index.json" in result
+    def test_instructs_result_file_not_index(self, executor):
+        result = executor._build_preamble("", "", 2)
+        # 자식은 result 파일에 쓰고 index.json은 건드리지 않아야 한다.
+        assert "step2.result.json" in result
+        assert "index.json은 절대 수정하지" in result
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +282,7 @@ class TestUpdateTopIndex:
     def test_completed(self, executor, top_index):
         executor._top_index_file = top_index
         executor._update_top_index("completed")
-        data = json.loads(top_index.read_text())
+        data = json.loads(top_index.read_text(encoding="utf-8"))
         mvp = next(p for p in data["phases"] if p["dir"] == "0-mvp")
         assert mvp["status"] == "completed"
         assert "completed_at" in mvp
@@ -288,7 +290,7 @@ class TestUpdateTopIndex:
     def test_error(self, executor, top_index):
         executor._top_index_file = top_index
         executor._update_top_index("error")
-        data = json.loads(top_index.read_text())
+        data = json.loads(top_index.read_text(encoding="utf-8"))
         mvp = next(p for p in data["phases"] if p["dir"] == "0-mvp")
         assert mvp["status"] == "error"
         assert "failed_at" in mvp
@@ -296,7 +298,7 @@ class TestUpdateTopIndex:
     def test_blocked(self, executor, top_index):
         executor._top_index_file = top_index
         executor._update_top_index("blocked")
-        data = json.loads(top_index.read_text())
+        data = json.loads(top_index.read_text(encoding="utf-8"))
         mvp = next(p for p in data["phases"] if p["dir"] == "0-mvp")
         assert mvp["status"] == "blocked"
         assert "blocked_at" in mvp
@@ -304,16 +306,16 @@ class TestUpdateTopIndex:
     def test_other_phases_unchanged(self, executor, top_index):
         executor._top_index_file = top_index
         executor._update_top_index("completed")
-        data = json.loads(top_index.read_text())
+        data = json.loads(top_index.read_text(encoding="utf-8"))
         polish = next(p for p in data["phases"] if p["dir"] == "1-polish")
         assert polish["status"] == "pending"
 
     def test_nonexistent_dir_is_noop(self, executor, top_index):
         executor._top_index_file = top_index
         executor._phase_dir_name = "no-such-dir"
-        original = json.loads(top_index.read_text())
+        original = json.loads(top_index.read_text(encoding="utf-8"))
         executor._update_top_index("completed")
-        after = json.loads(top_index.read_text())
+        after = json.loads(top_index.read_text(encoding="utf-8"))
         for p_before, p_after in zip(original["phases"], after["phases"]):
             assert p_before["status"] == p_after["status"]
 
@@ -429,27 +431,56 @@ class TestInvokeClaude:
         step = {"step": 2, "name": "ui"}
         preamble = "PREAMBLE\n"
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
-            output = executor._invoke_claude(step, preamble)
+        with patch.object(ex.shutil, "which", return_value="claude"), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            executor._invoke_claude(step, preamble)
 
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
         assert "-p" in cmd
         assert "--dangerously-skip-permissions" in cmd
         assert "--output-format" in cmd
-        assert "PREAMBLE" in cmd[-1]
-        assert "UI를 구현하세요" in cmd[-1]
+        # 프롬프트는 argv가 아니라 stdin(input=)으로 전달된다 (Windows 길이 한계 회피).
+        sent = mock_run.call_args[1]["input"]
+        assert "PREAMBLE" in sent
+        assert "UI를 구현하세요" in sent
+
+    def test_injects_harness_child_env(self, executor):
+        mock_result = MagicMock(returncode=0, stdout="{}", stderr="")
+        step = {"step": 2, "name": "ui"}
+        with patch.object(ex.shutil, "which", return_value="claude"), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            executor._invoke_claude(step, "preamble")
+        env = mock_run.call_args[1]["env"]
+        assert env.get("HARNESS_CHILD") == "1"
+
+    def test_missing_claude_cli_exits(self, executor):
+        step = {"step": 2, "name": "ui"}
+        with patch.object(ex.shutil, "which", return_value=None):
+            with pytest.raises(SystemExit) as exc_info:
+                executor._invoke_claude(step, "preamble")
+        assert exc_info.value.code == 1
+
+    def test_timeout_is_handled_gracefully(self, executor):
+        step = {"step": 2, "name": "ui"}
+        with patch.object(ex.shutil, "which", return_value="claude"), \
+             patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1800)):
+            output = executor._invoke_claude(step, "preamble")
+        assert output["exitCode"] == -1
+        assert "Timeout" in output["stderr"]
 
     def test_saves_output_json(self, executor):
         mock_result = MagicMock(returncode=0, stdout='{"ok": true}', stderr="")
         step = {"step": 2, "name": "ui"}
 
-        with patch("subprocess.run", return_value=mock_result):
+        with patch.object(ex.shutil, "which", return_value="claude"), \
+             patch("subprocess.run", return_value=mock_result):
             executor._invoke_claude(step, "preamble")
 
         output_file = executor._phase_dir / "step2-output.json"
         assert output_file.exists()
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         assert data["step"] == 2
         assert data["name"] == "ui"
         assert data["exitCode"] == 0
@@ -460,11 +491,12 @@ class TestInvokeClaude:
             executor._invoke_claude(step, "preamble")
         assert exc_info.value.code == 1
 
-    def test_timeout_is_1800(self, executor):
+    def test_timeout_kwarg_is_1800(self, executor):
         mock_result = MagicMock(returncode=0, stdout="{}", stderr="")
         step = {"step": 2, "name": "ui"}
 
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
+        with patch.object(ex.shutil, "which", return_value="claude"), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
             executor._invoke_claude(step, "preamble")
 
         assert mock_run.call_args[1]["timeout"] == 1800
@@ -524,7 +556,7 @@ class TestCheckBlockers:
         d = tmp_project / "phases" / "test-phase"
         d.mkdir(exist_ok=True)
         index = {"project": "T", "phase": "test", "steps": steps}
-        (d / "index.json").write_text(json.dumps(index))
+        (d / "index.json").write_text(json.dumps(index), encoding="utf-8")
 
         with patch.object(ex, "ROOT", tmp_project):
             inst = ex.StepExecutor.__new__(ex.StepExecutor)
@@ -557,3 +589,138 @@ class TestCheckBlockers:
         with pytest.raises(SystemExit) as exc_info:
             inst._check_blockers()
         assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# result 파일 머지 (N1: index.json은 부모 단독 소유)
+# ---------------------------------------------------------------------------
+
+class TestResultMerge:
+    def test_read_step_result_missing_returns_none(self, executor):
+        assert executor._read_step_result(2) is None
+
+    def test_read_step_result_parses(self, executor):
+        executor._result_file(2).write_text(
+            json.dumps({"status": "completed", "summary": "끝"}), encoding="utf-8"
+        )
+        result = executor._read_step_result(2)
+        assert result["status"] == "completed"
+        assert result["summary"] == "끝"
+
+    def test_read_step_result_corrupt_returns_none(self, executor):
+        executor._result_file(2).write_text("{not json", encoding="utf-8")
+        assert executor._read_step_result(2) is None
+
+    def test_set_step_fields_merges(self, executor):
+        executor._set_step_fields(2, status="completed", summary="done", completed_at="t")
+        index = ex.StepExecutor._read_json(executor._index_file)
+        s = index["steps"][2]
+        assert s["status"] == "completed"
+        assert s["summary"] == "done"
+        assert s["completed_at"] == "t"
+
+    def test_set_step_fields_none_removes(self, executor):
+        executor._set_step_fields(2, error_message="boom")
+        executor._set_step_fields(2, error_message=None)
+        index = ex.StepExecutor._read_json(executor._index_file)
+        assert "error_message" not in index["steps"][2]
+
+    def test_set_step_fields_preserves_other_steps(self, executor):
+        """자식이 자기 step만 바꿔도 다른 step의 summary가 보존돼야 한다 (N1 핵심)."""
+        executor._set_step_fields(2, status="completed", summary="ui done")
+        index = ex.StepExecutor._read_json(executor._index_file)
+        assert index["steps"][0]["summary"] == "프로젝트 초기화 완료"
+        assert index["steps"][1]["summary"] == "핵심 로직 구현"
+
+
+# ---------------------------------------------------------------------------
+# _write_json 원자성 (N5)
+# ---------------------------------------------------------------------------
+
+class TestAtomicWrite:
+    def test_no_tmp_left_behind(self, tmp_path):
+        p = tmp_path / "x.json"
+        ex.StepExecutor._write_json(p, {"a": 1})
+        assert p.exists()
+        assert not (tmp_path / "x.json.tmp").exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        p = tmp_path / "x.json"
+        ex.StepExecutor._write_json(p, {"v": 1})
+        ex.StepExecutor._write_json(p, {"v": 2})
+        assert ex.StepExecutor._read_json(p)["v"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _validate_plan (N4 스키마 선검증)
+# ---------------------------------------------------------------------------
+
+class TestValidatePlan:
+    def _exec(self, tmp_project, steps, files=("step0.md",)):
+        d = tmp_project / "phases" / "vp"
+        d.mkdir(exist_ok=True)
+        index = {"project": "T", "phase": "vp", "steps": steps}
+        (d / "index.json").write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
+        for f in files:
+            (d / f).write_text("# step", encoding="utf-8")
+        with patch.object(ex, "ROOT", tmp_project):
+            inst = ex.StepExecutor.__new__(ex.StepExecutor)
+        inst._phase_dir = d
+        inst._index_file = d / "index.json"
+        return inst
+
+    def test_valid_passes(self, tmp_project):
+        inst = self._exec(tmp_project, [{"step": 0, "name": "a", "status": "pending"}])
+        inst._validate_plan()  # no raise
+
+    def test_empty_steps_exits(self, tmp_project):
+        inst = self._exec(tmp_project, [])
+        with pytest.raises(SystemExit):
+            inst._validate_plan()
+
+    def test_non_sequential_exits(self, tmp_project):
+        inst = self._exec(tmp_project, [{"step": 1, "name": "a", "status": "pending"}])
+        with pytest.raises(SystemExit):
+            inst._validate_plan()
+
+    def test_missing_field_exits(self, tmp_project):
+        inst = self._exec(tmp_project, [{"step": 0, "status": "pending"}])
+        with pytest.raises(SystemExit):
+            inst._validate_plan()
+
+    def test_completed_after_pending_exits(self, tmp_project):
+        steps = [
+            {"step": 0, "name": "a", "status": "pending"},
+            {"step": 1, "name": "b", "status": "completed"},
+        ]
+        inst = self._exec(tmp_project, steps, files=("step0.md", "step1.md"))
+        with pytest.raises(SystemExit):
+            inst._validate_plan()
+
+    def test_missing_step_file_exits(self, tmp_project):
+        inst = self._exec(tmp_project, [{"step": 0, "name": "a", "status": "pending"}],
+                          files=())
+        with pytest.raises(SystemExit):
+            inst._validate_plan()
+
+
+# ---------------------------------------------------------------------------
+# _warn_placeholders (P1: 템플릿 미완성 감지)
+# ---------------------------------------------------------------------------
+
+class TestWarnPlaceholders:
+    def test_warns_but_continues_by_default(self, executor, capsys):
+        executor._strict = False
+        executor._warn_placeholders("기술 스택: {프레임워크}\n언어: {언어}")
+        out = capsys.readouterr().out
+        assert "placeholder" in out
+
+    def test_strict_aborts(self, executor):
+        executor._strict = True
+        with pytest.raises(SystemExit):
+            executor._warn_placeholders("{빈칸}")
+
+    def test_no_placeholder_silent(self, executor, capsys):
+        executor._strict = True
+        executor._warn_placeholders("완성된 문서입니다.")  # no raise
+        assert capsys.readouterr().out == ""

--- a/scripts/test_guard.py
+++ b/scripts/test_guard.py
@@ -1,0 +1,51 @@
+"""guard.py (PreToolUse 위험명령 차단기) 테스트."""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+import guard
+
+
+def _run(payload) -> int:
+    raw = json.dumps(payload) if not isinstance(payload, str) else payload
+    with patch.object(sys, "stdin", io.StringIO(raw)):
+        return guard.main()
+
+
+class TestGuard:
+    def test_allows_safe_command(self):
+        assert _run({"tool_name": "Bash", "tool_input": {"command": "ls -la"}}) == 0
+
+    def test_blocks_rm_rf(self):
+        assert _run({"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/x"}}) == 2
+
+    def test_blocks_git_push_force(self):
+        assert _run({"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}) == 2
+
+    def test_blocks_git_reset_hard(self):
+        assert _run({"tool_name": "Bash", "tool_input": {"command": "git reset --hard HEAD~3"}}) == 2
+
+    def test_blocks_drop_table(self):
+        assert _run({"tool_name": "Bash", "tool_input": {"command": "psql -c 'DROP TABLE users'"}}) == 2
+
+    def test_blocks_powershell_remove_item(self):
+        cmd = "Remove-Item -Recurse -Force C:\\data"
+        assert _run({"tool_name": "PowerShell", "tool_input": {"command": cmd}}) == 2
+
+    def test_no_false_positive_on_mention(self):
+        # 커밋 메시지에 'rm' 단어가 들어가도 실제 rm -rf 가 아니면 통과해야 한다.
+        cmd = "git commit -m 'document the rm helper'"
+        assert _run({"tool_name": "Bash", "tool_input": {"command": cmd}}) == 0
+
+    def test_empty_stdin_allows(self):
+        assert _run("") == 0
+
+    def test_malformed_json_allows(self):
+        assert _run("{not valid") == 0
+
+    def test_missing_command_allows(self):
+        assert _run({"tool_name": "Bash", "tool_input": {}}) == 0

--- a/scripts/test_verify.py
+++ b/scripts/test_verify.py
@@ -1,0 +1,60 @@
+"""verify.py (Stop 훅 자동감지 검증) 테스트."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+import verify
+
+
+class TestVerify:
+    def test_skips_when_harness_child(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setenv("HARNESS_CHILD", "1")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        assert verify.main() == 0
+
+    def test_skips_when_no_verify_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("HARNESS_CHILD", raising=False)
+        monkeypatch.setenv("HARNESS_NO_VERIFY", "1")
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        assert verify.main() == 0
+
+    def test_no_marker_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("HARNESS_CHILD", raising=False)
+        monkeypatch.delenv("HARNESS_NO_VERIFY", raising=False)
+        assert verify.main() == 0
+
+    def test_npm_project_runs_npm_checks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("HARNESS_CHILD", raising=False)
+        monkeypatch.delenv("HARNESS_NO_VERIFY", raising=False)
+        pkg = {"scripts": {"test": "jest", "build": "tsc"}}
+        (tmp_path / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+        called = []
+        with patch.object(verify, "_run", side_effect=lambda cmd, cwd: called.append(cmd) or 0):
+            assert verify.main() == 0
+        # build, test 두 스크립트가 실행돼야 한다 (lint는 없음)
+        assert len(called) == 2
+
+    def test_npm_failure_propagates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("HARNESS_CHILD", raising=False)
+        monkeypatch.delenv("HARNESS_NO_VERIFY", raising=False)
+        pkg = {"scripts": {"test": "jest"}}
+        (tmp_path / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+        with patch.object(verify, "_run", return_value=1):
+            assert verify.main() == 1
+
+    def test_python_project_runs_pytest(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.delenv("HARNESS_CHILD", raising=False)
+        monkeypatch.delenv("HARNESS_NO_VERIFY", raising=False)
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        with patch.object(verify, "_run", return_value=0) as m:
+            assert verify.main() == 0
+        assert m.called

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Stop 훅용 검증 스크립트 — 프로젝트 종류를 자동 감지해 lint/build/test를 실행한다.
+
+이 레포는 새 프로젝트마다 복사해 쓰는 재사용 하네스다. 따라서 npm을 하드코딩하지
+않고, 루트의 마커 파일을 보고 검증 커맨드를 고른다.
+
+종료 코드:
+    0 — 통과 (또는 검증할 것이 없음 / 스킵)
+    2 — 검증 실패. Claude Code Stop 훅은 2를 받으면 종료를 막고 stderr를 되먹인다.
+
+환경변수:
+    HARNESS_CHILD   — execute.py가 띄운 자식 세션 표시. 있으면 즉시 통과(재귀 방지).
+    HARNESS_NO_VERIFY — 검증을 일시적으로 끄는 탈출구. 있으면 즉시 통과.
+    CLAUDE_PROJECT_DIR — 프로젝트 루트. 없으면 현재 작업 디렉토리.
+"""
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Windows 콘솔(cp949)에서도 한글 메시지가 깨지지 않도록 stderr를 utf-8로 맞춘다.
+with contextlib.suppress(Exception):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+
+def _root() -> Path:
+    return Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+
+def _run(cmd: list[str], cwd: Path) -> int:
+    print(f"  [verify] $ {' '.join(cmd)}", file=sys.stderr)
+    try:
+        r = subprocess.run(cmd, cwd=str(cwd))
+        return r.returncode
+    except FileNotFoundError:
+        print(f"  [verify] '{cmd[0]}' 를 찾을 수 없어 건너뜁니다.", file=sys.stderr)
+        return 0
+
+
+def _npm_checks(root: Path) -> int:
+    """package.json에 정의된 lint/build/test 중 존재하는 것만 실행한다."""
+    try:
+        pkg = json.loads((root / "package.json").read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return 0
+    scripts = pkg.get("scripts", {})
+    npm = shutil.which("npm") or "npm"
+    for name in ("lint", "build", "test"):
+        if name in scripts:
+            code = _run([npm, "run", name], root)
+            if code != 0:
+                return code
+    return 0
+
+
+def _pytest_checks(root: Path) -> int:
+    if shutil.which("pytest") is None and shutil.which("py.test") is None:
+        # python -m pytest 로 시도
+        return _run([sys.executable, "-m", "pytest", "-q"], root)
+    return _run(["pytest", "-q"], root)
+
+
+def main() -> int:
+    if os.environ.get("HARNESS_CHILD") or os.environ.get("HARNESS_NO_VERIFY"):
+        return 0
+
+    root = _root()
+
+    # 우선순위: npm 프로젝트 → python 프로젝트 → 검증 대상 없음
+    if (root / "package.json").exists():
+        return _npm_checks(root)
+
+    py_markers = ("pyproject.toml", "requirements.txt", "pytest.ini", "setup.cfg")
+    if any((root / m).exists() for m in py_markers) or list(root.glob("test_*.py")):
+        return _pytest_checks(root)
+
+    # 감지된 마커가 없으면 검증할 것이 없으므로 통과한다.
+    return 0
+
+
+if __name__ == "__main__":
+    code = main()
+    if code != 0:
+        print(f"\n  [verify] 검증 실패 (exit {code}). 위 에러를 고치세요.", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(0)


### PR DESCRIPTION
## 개요
새 프로젝트마다 복사해 쓰는 재사용 하네스가 Windows/cp949에서 작동 불가 상태라 견고화했다. 테스트 87개 통과.

## P0 — 치명적
- 인코딩: execute.py 읽기·쓰기 utf-8 명시 (cp949 크래시 해소, 테스트 34개도 동시 복구)
- claude 호출: shutil.which 경로해석, 프롬프트 stdin 전달(Win 32k 한계), HARNESS_CHILD 재귀차단, Timeout 처리
- Stop 훅 → verify.py(프로젝트 자동감지), PreToolUse 훅 → guard.py(stdin JSON, Bash+PowerShell)

## P1 — 구조 개선
- index.json 단독 소유화(자식은 step{N}.result.json 보고→머지), 원자적 쓰기, 스키마/placeholder 검증

## P2/P3
- 신규 테스트, requirements-dev.txt, README, phases/example, 권한·gitignore 정리